### PR TITLE
:memo: doc: improve clarity and consistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The longer you rally the packets back and forth, the faster they travel, increas
 
 By default, the local host sends 4 ICMP ECHO packets (changeable with `-c`). When the last packet is returned or lost, or when the user quits the game, pong will display ping-style statistics summarizing the round-trip success and loss.
 
-It's ping meets pong — test your reflexes while staying true to the spirit of the network diagnostic classic.
+It's ping meets Pong — test your reflexes while staying true to the spirit of the network diagnostic classic.
 
 ## OPTIONS
 
@@ -72,8 +72,8 @@ go install github.com/yoshi389111/pong-is-not-ping/cmd/pong@latest
 ## SEE ALSO
 
 - Inspired by [kurehajime/pong-command](https://github.com/kurehajime/pong-command)
-- [POng is Not pinG. (dev.to)](https://dev.to/yoshi389111/pong-is-not-ping-323d) ― English article explaining this project
-- [Go言語でpingコマンドっぽい、でもpingコマンドじゃないpongコマンドを作ってみた (Qiita)](https://qiita.com/yoshi389111/items/a289f1c470616c5f10c4) ― Japanese article explaining this project
+- [POng is Not pinG. (dev.to)](https://dev.to/yoshi389111/pong-is-not-ping-323d) — English article explaining this project
+- [Go言語でpingコマンドっぽい、でもpingコマンドじゃないpongコマンドを作ってみた (Qiita)](https://qiita.com/yoshi389111/items/a289f1c470616c5f10c4) — Japanese article explaining this project
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ pong [OPTIONS] <DESTINATION>
 
 `pong` is a terminal-based game that parodies the classic ping utility. Instead of simply sending ICMP ECHO requests and waiting for replies, you play a Pong-style game with them.
 
-When you run `pong` with a target host, your local host (displayed on the left edge of the screen) will "send" ICMP ECHO packets as if they were Pong balls. The user controls the paddle on the right side (representing the target host) and must return these packets back to the local host.
+When you run `pong` with a target host specified as `<DESTINATION>`, your local host (displayed on the left edge of the screen) will "send" ICMP ECHO packets as if they were Pong balls. The user controls the paddle on the right side (representing the target host) and must return these packets back to the local host.
 
-Between them is the Gateway — a CPU-controlled paddle that always bounces the ICMP ECHO packets back toward the target host. The gateway doesn't understand that it should forward packets; it just reflects them blindly, reducing the TTL each time. You need to avoid the gateway’s deflections and ensure your packets make it back to the local host before their TTL expires (starting at 64 by default).
+Between them is the Gateway — a CPU-controlled paddle that always bounces the ICMP ECHO packets back toward the target host. The gateway doesn't understand that it should forward packets; it just reflects them blindly, reducing the TTL each time. You need to avoid the gateway’s deflections and ensure your packets make it back to the local host before their TTL expires (starting at 64 by default, changeable with `-t`).
 
 The longer you rally the packets back and forth, the faster they travel, increasing the difficulty.
 
-By default, the local host sends 4 ICMP ECHO packets. When the last packet is returned or lost, or when the user quits the game, pong will display ping-style statistics summarizing the round-trip success and loss.
+By default, the local host sends 4 ICMP ECHO packets (changeable with `-c`). When the last packet is returned or lost, or when the user quits the game, pong will display ping-style statistics summarizing the round-trip success and loss.
 
-It's ping meets Pong — test your reflexes while staying true to the spirit of the network diagnostic classic.
+It's ping meets pong — test your reflexes while staying true to the spirit of the network diagnostic classic.
 
 ## OPTIONS
 
@@ -39,14 +39,29 @@ It's ping meets Pong — test your reflexes while staying true to the spirit of 
   - Define the time to live (TTL) for the packets. The default is 64.
 
 - `-p`, `--padding=<pattern>`
-  - Specify the contents of the padding byte.
+  - Specify the padding string for ICMP echo packets.
 
 - `<DESTINATION>`
-  - The destination IP address or hostname to pong.
+  - Specify the target host by IP address or hostname.
 
 ## EXAMPLE
 
+```shell
+pong 192.168.1.1
+```
+
 ![pong](./docs/pong.gif)
+
+```console
+$ pong 192.168.1.1
+PONG 192.168.1.1(192.168.1.1) 9 bytes of data.
+9 bytes from 192.168.1.1: icmp_seq=1 ttl=51 time=63 sec
+9 bytes from 192.168.1.1: icmp_seq=2 ttl=63 time=16 sec
+9 bytes from 192.168.1.1: icmp_seq=3 ttl=62 time=21 sec
+9 bytes from 192.168.1.1: icmp_seq=4 ttl=61 time=25 sec
+--- 192.168.1.1 pong statistics ---
+4 packets transmitted, 4 packets received, 0% packet loss, time 133 sec
+```
 
 ## INSTALLATION
 
@@ -57,8 +72,8 @@ go install github.com/yoshi389111/pong-is-not-ping/cmd/pong@latest
 ## SEE ALSO
 
 - Inspired by [kurehajime/pong-command](https://github.com/kurehajime/pong-command)
-- dev.to [POng is Not pinG.](https://dev.to/yoshi389111/pong-is-not-ping-323d) English
-- qiita [Go言語でpingコマンドっぽい、でもpingコマンドじゃないpongコマンドを作ってみた](https://qiita.com/yoshi389111/items/a289f1c470616c5f10c4) Japanese
+- [POng is Not pinG. (dev.to)](https://dev.to/yoshi389111/pong-is-not-ping-323d) ― English article explaining this project
+- [Go言語でpingコマンドっぽい、でもpingコマンドじゃないpongコマンドを作ってみた (Qiita)](https://qiita.com/yoshi389111/items/a289f1c470616c5f10c4) ― Japanese article explaining this project
 
 ## LICENSE
 


### PR DESCRIPTION
This pull request updates the `README.md` file for the `pong` project to clarify usage instructions, improve descriptions, and provide examples. The most important changes include refining option descriptions, adding an example usage section, and enhancing links to related articles.

### Documentation Improvements:

* Clarified the description of the `-p` option to specify that it sets the padding string for ICMP echo packets. (`README.md`, [README.mdL42-R65](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R65))
* Updated the `<DESTINATION>` option to explicitly state it specifies the target host by IP address or hostname. (`README.md`, [README.mdL42-R65](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R65))
* Added an example usage section with a sample command and output to illustrate how the `pong` utility works. (`README.md`, [README.mdL42-R65](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R65))

### Enhanced Links:

* Improved formatting and descriptions for links to related articles, distinguishing between English and Japanese resources. (`README.md`, [README.mdL60-R76](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R76))