### PR TITLE
:art: style: update copyright formatting in LICENSE and README.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 SATO, Yoshiyuki
+Copyright (c) 2022 SATO Yoshiyuki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ go install github.com/yoshi389111/pong-is-not-ping/cmd/pong@latest
 - [POng is Not pinG. (dev.to)](https://dev.to/yoshi389111/pong-is-not-ping-323d) — English article explaining this project
 - [Go言語でpingコマンドっぽい、でもpingコマンドじゃないpongコマンドを作ってみた (Qiita)](https://qiita.com/yoshi389111/items/a289f1c470616c5f10c4) — Japanese article explaining this project
 
-## LICENSE
+## COPYRIGHT
 
-This software is released under the MIT License.
-
-&copy; 2022 SATO, Yoshiyuki
+&copy; 2022 SATO Yoshiyuki. MIT Licensed.


### PR DESCRIPTION
This pull request includes minor updates to the copyright information and documentation for clarity and consistency.

**Documentation updates:**

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Removed the comma in the author's name to align with standard formatting.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R80): Updated the "LICENSE" section to "COPYRIGHT" and rephrased the copyright statement for improved clarity. The author's name formatting was also updated to match the change in `LICENSE`.